### PR TITLE
Add refresh available list button

### DIFF
--- a/meg_runtime/ui/addpluginpanel.py
+++ b/meg_runtime/ui/addpluginpanel.py
@@ -32,6 +32,8 @@ class AddPluginPanel(BasePanel):
         self.available_radio_button = instance.findChild(QtWidgets.QRadioButton, 'availableRadioButton')
         self.available_radio_button.clicked.connect(self.enable_available_selection)
         self.available_plugin_list = instance.findChild(QtWidgets.QTreeWidget, 'availablePluginList')
+        self.refresh_available_button = instance.findChild(QtWidgets.QPushButton, 'refreshAvailableButton')
+        self.refresh_available_button.clicked.connect(self.refreshAvailableList)
         # file plugin handlers
         self.file_radio_button = instance.findChild(QtWidgets.QRadioButton, 'fileRadioButton')
         self.file_radio_button.clicked.connect(self.enable_file_selection)
@@ -46,12 +48,12 @@ class AddPluginPanel(BasePanel):
     def reset_form(self):
         """clear all form values"""
         self.available_radio_button.setChecked(True)
-        self.available_plugin_list.clear()
         self.file_label.setText('')
         self.url_field.setText('')
     
     def bind_available_plugins(self):
         """Add all available plugins to the available plugin list"""
+        self.available_plugin_list.clear()
         available_plugins = PluginManager.get_all_available()
         for plugin in available_plugins:
             self.available_plugin_list.addTopLevelItem(QtWidgets.QTreeWidgetItem([
@@ -125,3 +127,8 @@ class AddPluginPanel(BasePanel):
         messageBox.setIcon(QtWidgets.QMessageBox.Critical)
         messageBox.setText(message)
         messageBox.exec()
+    
+    def refreshAvailableList(self):
+        """refresh list of available plugins"""
+        PluginManager.update_cache()
+        self.bind_available_plugins()

--- a/meg_runtime/ui/addpluginpanel.ui
+++ b/meg_runtime/ui/addpluginpanel.ui
@@ -55,6 +55,45 @@
     </widget>
    </item>
    <item>
+    <widget class="QWidget" name="horizontalWidget" native="true">
+     <property name="minimumSize">
+      <size>
+       <width>0</width>
+       <height>20</height>
+      </size>
+     </property>
+     <layout class="QHBoxLayout" name="horizontalLayout_3">
+      <item>
+       <spacer name="horizontalSpacer_3">
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>40</width>
+          <height>20</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
+      <item>
+       <widget class="QPushButton" name="refreshAvailableButton">
+        <property name="text">
+         <string>Refresh List</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
+    <widget class="Line" name="line">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+    </widget>
+   </item>
+   <item>
     <widget class="QRadioButton" name="fileRadioButton">
      <property name="text">
       <string>Select File</string>
@@ -110,6 +149,13 @@
     </widget>
    </item>
    <item>
+    <widget class="Line" name="line_2">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+    </widget>
+   </item>
+   <item>
     <widget class="QRadioButton" name="urlRadioButton">
      <property name="text">
       <string>Provide Plugin URL</string>
@@ -120,6 +166,13 @@
     <widget class="QLineEdit" name="urlField">
      <property name="enabled">
       <bool>false</bool>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="Line" name="line_3">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
      </property>
     </widget>
    </item>


### PR DESCRIPTION
This adds a pr to refresh the available list of plugins. Sometimes, the list can update while the user is unaware, so they need a refresh button to see the list.

That, and the list wasn't loading on initial component load. 